### PR TITLE
feat: Enhance Desktop Build Action with Build Type and Outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,107 @@
-# KMP Build Desktop App GitHub Action
+# KMP Desktop Build Action
 
 ## Overview
 
-This GitHub Action is designed to build desktop applications for multiple platforms (Windows, Linux, MacOS) using Kotlin Multiplatform (KMP) and Gradle. It automates the process of setting up the development environment, building the application, and uploading platform-specific artifacts.
+This GitHub Action automates the build process for cross-platform desktop applications, supporting multiple operating systems and build configurations.
 
 ## Features
 
-- Sets up Java 17 development environment using Zulu OpenJDK
-- Configures Gradle build system
-- Implements caching to speed up subsequent builds
-- Packages desktop application for the current operating system
-- Uploads platform-specific executables and installers as artifacts
+- 🖥️ Cross-platform support (Windows, macOS, Linux)
+- 🛠️ Flexible build type configuration (Debug/Release)
+- 📦 Automatic artifact generation and upload
+- 🚀 Gradle build caching for improved performance
 
 ## Inputs
 
 ### `desktop_package_name`
 - **Description**: Name of the desktop project module
-- **Required**: Yes
-- **Type**: String
+- **Required**: `true`
+- **Type**: `string`
+- **Example**: `'mydesktopapp'`
 
-## Platforms Supported
+### `build_type`
+- **Description**: Type of build to perform
+- **Required**: `false`
+- **Default**: `'Debug'`
+- **Accepted Values**:
+   - `'Debug'`
+   - `'Release'`
 
-- Windows
-- Linux (Ubuntu)
-- macOS
+## Outputs
 
-## Usage Example
+### Platform-Specific App Paths
+- `windows_app`: Path to Windows executable/installer
+- `linux_app`: Path to Linux package
+- `macos_app`: Path to macOS package
 
+### Platform-Specific Artifact Names
+- **Windows**: `Windows-Apps`
+   - Contains: `.exe` and `.msi` files
+- **Linux**: `Linux-App`
+   - Contains: `.deb` files
+- **macOS**: `MacOS-App`
+   - Contains: `.dmg` files
+
+## Usage Examples
+
+### Basic Debug Build
 ```yaml
-jobs:
-  build-desktop-app:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: openMF/kmp-build-desktop-app-action@v1.0.0
-        with:
-          desktop_package_name: 'my-desktop-module'
+  build_desktop:
+     name: Build Desktop App
+     strategy:
+        matrix:
+           os: [ ubuntu-latest, macos-latest, windows-latest ]
+     runs-on: ${{ matrix.os }}
+     steps:
+        - name: Checkout Repository
+          uses: actions/checkout@v4
+          
+        - name: Build Desktop App
+          uses: openMF/kmp-build-desktop-app-action@v1.0.0
+          with:
+            desktop_package_name: 'myapp'
 ```
 
-## Build Process
+### Release Build
+```yaml
+  build_desktop:
+     name: Build Desktop App
+     strategy:
+        matrix:
+           os: [ ubuntu-latest, macos-latest, windows-latest ]
+     runs-on: ${{ matrix.os }}
+     steps:
+        - name: Checkout Repository
+          uses: actions/checkout@v4
 
-The action performs the following steps:
+        - name: Build Desktop App
+          uses: openMF/kmp-build-desktop-app-action@v1.0.0
+          with:
+            desktop_package_name: 'myapp'
+            build_type: 'Release'
+```
 
-1. Set up Java 17 development environment using Zulu OpenJDK
-2. Configure Gradle build system
-3. Cache Gradle dependencies and build outputs
-4. Package desktop application using `./gradlew packageDistributionForCurrentOS`
-5. Upload platform-specific artifacts:
-    - Windows: `.exe` and `.msi` files
-    - Linux: `.deb` files
-    - macOS: `.dmg` files
+## Best Practices
 
-## Prerequisites
+- Always specify the `desktop_package_name`
+- Use `Release` build type for production distributions
+- Check artifact names carefully when downloading
+- Verify file integrity after download
 
-- A Kotlin Multiplatform project configured for desktop application development
-- Gradle wrapper in the project
-- Gradle task `packageDistributionForCurrentOS` defined for building desktop distributions
+## Troubleshooting
 
-## Recommendations
+### Common Issues
+- Ensure Gradle build script is correctly configured
+- Check that packaging commands match your project structure
+- Verify Java 17 is installed and compatible
 
-- Ensure your Gradle build script includes the necessary configuration for packaging desktop applications
-- Test the action in your project's continuous integration workflow
-- Verify that the `packageDistributionForCurrentOS` task works correctly locally before integrating this action
+### Debugging
+- Review GitHub Actions logs for detailed build information
+- Check Gradle build output for specific errors
+- Ensure all required dependencies are included in the build
+
+## Requirements
+
+- Java 17
+- Gradle
+- Compatible Kotlin Multiplatform Desktop configuration

--- a/action.yaml
+++ b/action.yaml
@@ -10,14 +10,32 @@ inputs:
     description: 'Name of the desktop project module'
     required: true
 
+  build_type:
+    description: 'Type of build to perform (Debug or Release)'
+    required: false
+    default: 'Debug'
+
+outputs:
+  windows_app:
+    description: 'Path to Windows executable/installer'
+    value: ${{ steps.collect-apps.outputs.windows_app }}
+
+  linux_app:
+    description: 'Path to Linux package'
+    value: ${{ steps.collect-apps.outputs.linux_app }}
+
+  macos_app:
+    description: 'Path to MacOS package'
+    value: ${{ steps.collect-apps.outputs.macos_app }}
+
 runs:
   using: 'composite'
   steps:
     - name: Set up Java development environment
       uses: actions/setup-java@v4
       with:
-        distribution: 'zulu'  # Use Zulu distribution of OpenJDK
-        java-version: '17'     # Use Java 17 version
+        distribution: 'zulu'
+        java-version: '17'
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
@@ -35,7 +53,32 @@ runs:
 
     - name: Package Desktop App
       shell: bash
-      run: ./gradlew packageDistributionForCurrentOS
+      run: |
+        # Determine the package command based on build type
+        if [[ "${{ inputs.build_type }}" == "Release" ]]; then
+          ./gradlew packageReleaseDistributionForCurrentOS
+        else
+          ./gradlew packageDistributionForCurrentOS
+        fi
+
+    - name: Collect App Paths
+      id: collect-apps
+      shell: bash
+      run: |
+        # Find app paths for each OS
+        windows_app=$(find . -path "**/*.exe" -o -path "**/*.msi" | grep -E "windows|win" | head -n 1)
+        linux_app=$(find . -path "**/*.deb" | head -n 1)
+        macos_app=$(find . -path "**/*.dmg" | head -n 1)
+
+        # Output app paths
+        echo "windows_app=${windows_app}" >> $GITHUB_OUTPUT
+        echo "linux_app=${linux_app}" >> $GITHUB_OUTPUT
+        echo "macos_app=${macos_app}" >> $GITHUB_OUTPUT
+
+        # Print for logging
+        echo "Windows App: ${windows_app}"
+        echo "Linux App: ${linux_app}"
+        echo "MacOS App: ${macos_app}"
 
     # Upload Windows executables and installers
     - name: Upload Windows Apps


### PR DESCRIPTION
This commit enhances the KMP Desktop Build Action with the following improvements:

- **Flexible Build Type:** Added support for specifying the build type (Debug or Release) through the `build_type` input. Defaults to `Debug`.
- **Outputs:** Added outputs to provide access to platform-specific app paths after the build process. This includes paths to Windows, Linux, and macOS packages.
- **Improved documentation:** The README has been extensively updated with clearer usage instructions, examples, troubleshooting tips, and an improved structure.
- **Artifact Names:** Clarified artifact names for easier identification.
- **Release Build Support:** Added a release build option using the `packageReleaseDistributionForCurrentOS` Gradle task.
- **Detailed Build Steps:** Refactored the build step to dynamically select the appropriate packaging task based on the build type.
- **App Path Collection:** Added a dedicated step to collect and output platform-specific application paths for easier access in downstream workflows.