### PR TITLE
refactor: Update artifact names and remove platform-specific outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,37 +11,6 @@ This GitHub Action automates the build process for cross-platform desktop applic
 - 📦 Automatic artifact generation and upload
 - 🚀 Gradle build caching for improved performance
 
-## Inputs
-
-### `desktop_package_name`
-- **Description**: Name of the desktop project module
-- **Required**: `true`
-- **Type**: `string`
-- **Example**: `'mydesktopapp'`
-
-### `build_type`
-- **Description**: Type of build to perform
-- **Required**: `false`
-- **Default**: `'Debug'`
-- **Accepted Values**:
-   - `'Debug'`
-   - `'Release'`
-
-## Outputs
-
-### Platform-Specific App Paths
-- `windows_app`: Path to Windows executable/installer
-- `linux_app`: Path to Linux package
-- `macos_app`: Path to macOS package
-
-### Platform-Specific Artifact Names
-- **Windows**: `Windows-Apps`
-   - Contains: `.exe` and `.msi` files
-- **Linux**: `Linux-App`
-   - Contains: `.deb` files
-- **macOS**: `MacOS-App`
-   - Contains: `.dmg` files
-
 ## Usage Examples
 
 ### Basic Debug Build
@@ -80,6 +49,32 @@ This GitHub Action automates the build process for cross-platform desktop applic
             desktop_package_name: 'myapp'
             build_type: 'Release'
 ```
+
+## Inputs
+
+### `desktop_package_name`
+- **Description**: Name of the desktop project module
+- **Required**: `true`
+- **Type**: `string`
+- **Example**: `'mydesktopapp'`
+
+### `build_type`
+- **Description**: Type of build to perform
+- **Required**: `false`
+- **Default**: `'Debug'`
+- **Accepted Values**:
+   - `'Debug'`
+   - `'Release'`
+
+## Outputs
+
+### Platform-Specific Artifact Names
+- **Windows**: `Windows-Apps`
+   - Contains: `.exe` and `.msi` files
+- **Linux**: `Linux-App`
+   - Contains: `.deb` files
+- **macOS**: `MacOS-App`
+   - Contains: `.dmg` files
 
 ## Best Practices
 

--- a/action.yaml
+++ b/action.yaml
@@ -15,19 +15,6 @@ inputs:
     required: false
     default: 'Debug'
 
-outputs:
-  windows_app:
-    description: 'Path to Windows executable/installer'
-    value: ${{ steps.collect-apps.outputs.windows_app }}
-
-  linux_app:
-    description: 'Path to Linux package'
-    value: ${{ steps.collect-apps.outputs.linux_app }}
-
-  macos_app:
-    description: 'Path to MacOS package'
-    value: ${{ steps.collect-apps.outputs.macos_app }}
-
 runs:
   using: 'composite'
   steps:
@@ -61,31 +48,12 @@ runs:
           ./gradlew packageDistributionForCurrentOS
         fi
 
-    - name: Collect App Paths
-      id: collect-apps
-      shell: bash
-      run: |
-        # Find app paths for each OS
-        windows_app=$(find . -path "**/*.exe" -o -path "**/*.msi" | grep -E "windows|win" | head -n 1)
-        linux_app=$(find . -path "**/*.deb" | head -n 1)
-        macos_app=$(find . -path "**/*.dmg" | head -n 1)
-
-        # Output app paths
-        echo "windows_app=${windows_app}" >> $GITHUB_OUTPUT
-        echo "linux_app=${linux_app}" >> $GITHUB_OUTPUT
-        echo "macos_app=${macos_app}" >> $GITHUB_OUTPUT
-
-        # Print for logging
-        echo "Windows App: ${windows_app}"
-        echo "Linux App: ${linux_app}"
-        echo "MacOS App: ${macos_app}"
-
-    # Upload Windows executables and installers
+    # Upload Windows executables
     - name: Upload Windows Apps
       if: matrix.os == 'windows-latest'
       uses: actions/upload-artifact@v4
       with:
-        name: Windows-Apps
+        name: desktop-app-${{ matrix.os }}
         path: |
           **/*.exe
           **/*.msi
@@ -95,7 +63,7 @@ runs:
       if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v4
       with:
-        name: Linux-App
+        name: desktop-app-${{ matrix.os }}
         path: '**/*.deb'
 
     # Upload MacOS package
@@ -103,5 +71,5 @@ runs:
       if: matrix.os == 'macos-latest'
       uses: actions/upload-artifact@v4
       with:
-        name: MacOS-App
+        name: desktop-app-${{ matrix.os }}
         path: '**/*.dmg'


### PR DESCRIPTION
This commit refactors the KMP Desktop Build Action by updating artifact names and removing the platform-specific app path outputs.

- Updated artifact names to reflect the target platform, resulting in a more consistent naming scheme.
- Removed the step and outputs previously used to collect and output app paths for each operating system.
- Reorganized and improved documentation for clarity and accuracy.